### PR TITLE
Homepage pop up: Incorrect position on Firefox

### DIFF
--- a/script/cultural-advice-modal.js
+++ b/script/cultural-advice-modal.js
@@ -20,7 +20,6 @@ var styles = `
 	top: 0;
 	height: 100vh;
 	height: 100%; /* Fallback */
-	height: -moz-available;
 	height: -webkit-fill-available;
 	height: fill-available;
 	height: stretch; /* Latest specification */

--- a/script/prelaunch-modal.js
+++ b/script/prelaunch-modal.js
@@ -19,7 +19,6 @@ var styles = `
 	top: 0;
 	height: 100vh;
 	height: 100%; /* Fallback */
-	height: -moz-available;
 	height: -webkit-fill-available;
 	height: fill-available;
 	height: stretch; /* Latest specification */


### PR DESCRIPTION
Issue specific to Firefox caused by -moz-available line in CSS within pop-up script
Before:
![image](https://github.com/uwalibrary/uwa-collected/assets/113404105/68f0e0ae-16fb-434c-ac81-65f0cc9c2936)
After:
![image](https://github.com/uwalibrary/uwa-collected/assets/113404105/338d968e-1491-4627-8a75-3ce92c9365c8)
